### PR TITLE
Added example of in-line R syntax to replace screenshot

### DIFF
--- a/04_quarto.qmd
+++ b/04_quarto.qmd
@@ -249,7 +249,7 @@ exercise_number <- exercise_number + 1
 
 ### 3. Code chunks
 
-![](images/inline-r-code.png)
+We can add in-line R code to a Quarto document with `` `r knitr::inline_expr("2+2")` ``.
 
 More frequently, code is added in code chunks:
 


### PR DESCRIPTION
Removed need to use a screenshot.

See reference here: <https://bookdown.org/yihui/rmarkdown-cookbook/verbatim-code-chunks.html#show-a-verbatim-inline-expression>